### PR TITLE
Misc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ When flashing applications using ``west``, this will invoke the ``nrfjprog`` run
 This runner will use the system default configuration that will configure the application in the QSPI mode (when flashing the external flash).
 This behavior can be changed using a custom ``Qspi.ini`` configuration file, but this will prevent flashing from being performed using ``west``. A sample ``Qspi.ini`` file is provided in the root of this repository. The file is set up to work on Nordic Thingy:53. If you decide to use the ``Qspi.ini`` file, the HEX files in the repository need to be manually flashed. For example, for the ``zigbee_weather_station`` application, the files to flash are the following (paths are relative to the build directory):
 
-* multiprotocol_rpmsg/zephyr/merged_CPUNET.hex
+* 802154_rpmsg/zephyr/merged_CPUNET.hex
 * mcuboot/zephyr/zephyr.hex
 * zephyr/internal_flash_signed.hex
 * zephyr/qspi_flash_signed.hex
@@ -249,7 +249,7 @@ For the ``smp_svr`` sample application, the files to flash are the following:
 The follow commands can be used to flash and verify the application for ``zigbee_weather_station`` (adjusting the path to the ini file):
 
 ```
-nrfjprog -f NRF53 --coprocessor CP_NETWORK --sectorerase --program multiprotocol_rpmsg/zephyr/merged_CPUNET.hex --verify
+nrfjprog -f NRF53 --coprocessor CP_NETWORK --sectorerase --program 802154_rpmsg/zephyr/merged_CPUNET.hex --verify
 nrfjprog -f NRF53 --sectorerase --program mcuboot/zephyr/zephyr.hex --verify
 nrfjprog -f NRF53 --sectorerase --program zephyr/internal_flash_signed.hex --verify
 nrfjprog -f NRF53 --qspisectorerase --program zephyr/qspi_flash_signed.hex --qspiini <path_to>/Qspi.ini --verify

--- a/zigbee_weather_station/CMakeLists.txt
+++ b/zigbee_weather_station/CMakeLists.txt
@@ -11,6 +11,9 @@ cmake_minimum_required(VERSION 3.20.0)
 # The application uses the configuration/<board> scheme for configuration files.
 set(APPLICATION_CONFIG_DIR "${CMAKE_CURRENT_SOURCE_DIR}/configuration/\${BOARD}")
 
+# Specify partition manager file
+set(PM_STATIC_YML_FILE "${CMAKE_CURRENT_SOURCE_DIR}/pm_static.yml")
+
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ZigbeeWeatherStation)
 


### PR DESCRIPTION
    zigbee_weather_station: Fix not using application static PM file
    
    Fixes an issue whereby the application's static PM file was not
    being used

    readme: Fix incorrect filename
    
    Fixes using an incorrect image name
